### PR TITLE
Rate Limit Storage

### DIFF
--- a/app/twitter/ThreadedCollector.py
+++ b/app/twitter/ThreadedCollector.py
@@ -198,10 +198,16 @@ class fileOutListener(StreamListener):
         self.logger.warning('COLLECTION LISTENER: Stream rate limiting caused us to miss %s tweets' % (message['limit'].get('track')))
         print 'Stream rate limiting caused us to miss %s tweets' % (message['limit'].get('track'))
 
-        rate_limit_info = { 'date': now, 'lost_count': int(message['limit'].get('track')) }
-        self.project_config_db.update({
-            '_id': ObjectId(self.collector_id)},
-            {"$push": {"stream_limit_loss.counts": rate_limit_info}})
+        message['limit']['time'] = time.strftime('%Y-%m-%dT%H:%M:%S')
+
+        time_str = time.strftime(self.tweetsOutFileDateFrmt)
+        JSON_file_name = self.tweetsOutFilePath + time_str + '-' + self.collector['collector_name'] + '-streamlimits-' + self.project_id + '-' + self.collector_id + '-' + self.tweetsOutFile
+        if not os.path.isfile(JSON_file_name):
+            self.logger.info('Creating new stream limit file: %s' % JSON_file_name)
+
+        with open(JSON_file_name, 'a') as stream_limit_file:
+            stream_limit_file.write(json.dumps(message).encode('utf-8'))
+            stream_limit_file.write('\n')
 
         # Total tally
         self.limit_count += int(message['limit'].get('track'))

--- a/app/views.py
+++ b/app/views.py
@@ -207,7 +207,10 @@ def home(project_name, task_id=None):
         project_detail['num_collectors'] = len(project_detail['collectors'])
 
         for collector in project_detail['collectors']:
-            collector['num_terms'] = len(collector['terms_list'])
+            collector['num_terms'] = 0
+
+            if collector['terms_list'] is not None:
+                collector['num_terms'] = len(collector['terms_list'])
     else:
         project_detail['num_collectors'] = 0
 
@@ -233,7 +236,11 @@ def network_home(project_name, network, task_id=None):
     else:
         collectors = [c for c in g.project['collectors'] if c['network'] == network]
         for collector in collectors:
-            collector['num_terms'] = len(collector['terms_list'])
+            collector['num_terms'] = 0
+
+            if collector['terms_list'] is not None:
+                collector['num_terms'] = len(collector['terms_list'])
+
         g.project['num_collectors'] = len(collectors)
 
     processor_form = ProcessControlForm(request.form)


### PR DESCRIPTION
- STACKS now collects stream limit notices via raw JSON files and passes them down the insertion pipeline.
- We also collect limit counts in Mongo per collector (vs. project-wide limit counts stored in Mongo)
- Limit notices are stored in a project's main DB under the "limits" collection
- Limit notices are formatted as such, where the "track" key notes the number of tweets missed and "timestamp_ms" is a Unix style timestamp of the limit notice

``` JSON
 { "limit": { "track": "X", "time": "YYYY-MM-DDTHH:MM:SS", "timestamp_ms": "X"}}
```

**Questions**
1. Do we want to include count reports somewhere on the front-end of STACKS. If so, where?
2. Since the limits collection will contain notices for all collectors in an account, should we include an additional field that notes the collector name for the limit notice?

/cc
@jhemsley 
