### PR TITLE
Status Emails + Stream Rate Limit Logging

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -54,12 +54,13 @@ if __name__ == "__main__":
             """
 
             project_name = raw_input('Project Name: ')
+            email = raw_input('Email: ')
             password = raw_input('Password: ')
             description = raw_input('Description: ')
 
             hashed_password = generate_password_hash(password)
 
-            resp = db.create(project_name, password, hashed_password, description)
+            resp = db.create(project_name, password, hashed_password, description=description, email=email)
             print json.dumps(resp, indent=1)
 
         elif method == 'auth':

--- a/app/forms.py
+++ b/app/forms.py
@@ -48,6 +48,7 @@ class CreateForm(Form):
     Project account creation form
     """
     project_name = StringField('Project Name', [DataRequired()])
+    email = StringField('Email', [DataRequired()])
     password = PasswordField('Password', [DataRequired()])
     confirm = PasswordField('Confirm Password', [
         DataRequired(),

--- a/app/models.py
+++ b/app/models.py
@@ -340,6 +340,7 @@ class DB(object):
             'params'            : params,
             'collector'         : {'run': 0, 'collect': 0, 'update': 0},
             'active'            : 0,
+            'listener_running'  : False,
             'languages'         : languages,
             'location'          : location,
             'rate_limits'       : [],

--- a/app/models.py
+++ b/app/models.py
@@ -17,7 +17,8 @@ class DB(object):
         self.config_db = self.connection.config
         self.stack_config = self.config_db.config
 
-    def create(self, project_name, password, hashed_password, description=None, admin=False):
+    def create(self, project_name, password, hashed_password, description=None,
+               admin=False, email=None):
         """
         Creates a project account with given name, password, and description
         """
@@ -56,6 +57,7 @@ class DB(object):
                     'project_name': project_name,
                     'password': hashed_password,
                     'description': description,
+                    'email': email,
                     'collectors': [],
                     'configdb': configdb,
                     'admin': 0

--- a/app/templates/create.html
+++ b/app/templates/create.html
@@ -10,6 +10,7 @@
       <form method="POST" action="/create" class="form">
         {{ form.csrf_token }}
         {{ form_field(form.project_name, inner_text="Enter a project name") }}
+        {{ form_field(form.email, inner_text="Enter your email") }}
         {{ form_field(form.password, inner_text="Enter a password") }}
         {{ form_field(form.confirm, inner_text="Confirm your password") }}
         {{ form_field(form.description, inner_text="Enter a brief account description") }}

--- a/app/twitter/ThreadedCollector.py
+++ b/app/twitter/ThreadedCollector.py
@@ -198,10 +198,16 @@ class fileOutListener(StreamListener):
         self.logger.warning('COLLECTION LISTENER: Stream rate limiting caused us to miss %s tweets' % (message['limit'].get('track')))
         print 'Stream rate limiting caused us to miss %s tweets' % (message['limit'].get('track'))
 
-        rate_limit_info = { 'date': now, 'lost_count': int(message['limit'].get('track')) }
-        self.project_config_db.update({
-            '_id': ObjectId(self.collector_id)},
-            {"$push": {"stream_limit_loss.counts": rate_limit_info}})
+        message['limit']['time'] = time.strftime('%Y-%m-%dT%H:%M:%S')
+
+        time_str = time.strftime(self.tweetsOutFileDateFrmt)
+        JSON_file_name = self.tweetsOutFilePath + time_str + '-' + self.collector['collector_name'] + '-streamlimits-' + self.project_id + '-' + self.collector_id + '-' + self.tweetsOutFile
+        if not os.path.isfile(JSON_file_name):
+            self.logger.info('Creating new stream limit file: %s' % JSON_file_name)
+
+        with open(JSON_file_name, 'a') as stream_limit_file:
+            stream_limit_file.write(json.dumps(message).encode('utf-8'))
+            stream_limit_file.write('\n')
 
         # Total tally
         self.limit_count += int(message['limit'].get('track'))

--- a/app/views.py
+++ b/app/views.py
@@ -150,13 +150,14 @@ def create():
     if form.validate_on_submit():
         # On submit, grab form information
         project_name = form.project_name.data
+        email = form.email.data
         password = form.password.data
         hashed_password = generate_password_hash(password)
         description = form.description.data
 
         # Create the account
         db = DB()
-        resp = db.create(project_name, password, hashed_password, description)
+        resp = db.create(project_name, password, hashed_password, description=description, email=email)
         if resp['status']:
             flash(u'Project successfully created!')
             return redirect(url_for('admin_home', admin_id=g.admin['project_id']))

--- a/app/views.py
+++ b/app/views.py
@@ -207,7 +207,10 @@ def home(project_name, task_id=None):
         project_detail['num_collectors'] = len(project_detail['collectors'])
 
         for collector in project_detail['collectors']:
-            collector['num_terms'] = len(collector['terms_list'])
+            collector['num_terms'] = 0
+
+            if collector['terms_list'] is not None:
+                collector['num_terms'] = len(collector['terms_list'])
     else:
         project_detail['num_collectors'] = 0
 
@@ -233,7 +236,11 @@ def network_home(project_name, network, task_id=None):
     else:
         collectors = [c for c in g.project['collectors'] if c['network'] == network]
         for collector in collectors:
-            collector['num_terms'] = len(collector['terms_list'])
+            collector['num_terms'] = 0
+
+            if collector['terms_list'] is not None:
+                collector['num_terms'] = len(collector['terms_list'])
+
         g.project['num_collectors'] = len(collectors)
 
     processor_form = ProcessControlForm(request.form)

--- a/install
+++ b/install
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-pip install requirements.txt
+pip install -r requirements.txt
 crontab scripts/crontab.txt

--- a/install
+++ b/install
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pip install requirements.txt
+crontab scripts/crontab.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,9 @@ MarkupSafe==0.23
 pymongo==2.7.2
 pytz==2014.7
 requests==2.7.0
+sendgrid==1.4.2
 simplejson==3.6.3
+smtpapi==0.2.0
 tweepy==2.3.0
 Werkzeug==0.9.6
 wheel==0.24.0

--- a/scripts/check_collectors.py
+++ b/scripts/check_collectors.py
@@ -1,0 +1,25 @@
+import os
+
+from check_processes import check_process_pid
+
+def get_collector_status(project, collector):
+    base_dir = os.path.split(os.path.abspath(os.path.dirname(__file__)))[0]
+    pid_dir = base_dir\
+        + '/out/'\
+        + project['project_name']\
+        + '-'\
+        + project['id']\
+        + '/pid'
+
+    process_name = project['project_name']\
+        + '-'\
+        + collector['collector_name']\
+        + '-collect-'\
+        + collector['network']\
+        + '-'\
+        + collector['id']
+
+    pidfile = pid_dir + '/' + process_name + '.pid'
+    collector['daemon_running'] = check_process_pid(pidfile)
+
+    return collector

--- a/scripts/check_processes.py
+++ b/scripts/check_processes.py
@@ -1,0 +1,28 @@
+import os
+
+def pid_alive(pid):
+    """
+    Uses OS Kill signal 0 to check if the process with given pid is running
+    Via - http://stackoverflow.com/questions/568271/how-to-check-if-there-exists-a-process-with-a-given-pid
+    """
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+def check_process_pid(pidfile):
+    """
+    A) If the pidfile doesn't exist, return false
+    B) If the pidfile exists, call pid_alive to check if process is actually running
+    """
+    try:
+        pf = file(pidfile, 'r')
+        pid = int(pf.read().strip())
+        pf.close()
+        return pid_alive(pid)
+    except IOError:
+        return False
+    except SystemExit:
+        return False

--- a/scripts/crontab.txt
+++ b/scripts/crontab.txt
@@ -3,4 +3,4 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:
 
 # m h dom mon dow command
 0/15 * * * * python $( pwd )/stack/scripts/status_checker.py system_check
-* 18 * * * python $( pwd )/stack/scripts/status_checker.py report
+0 18 * * * python $( pwd )/stack/scripts/status_checker.py report

--- a/scripts/crontab.txt
+++ b/scripts/crontab.txt
@@ -1,0 +1,6 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:
+
+# m h dom mon dow command
+0/15 * * * * python $( pwd )/stack/scripts/status_checker.py system_check
+* 18 * * * python $( pwd )/stack/scripts/status_checker.py report

--- a/scripts/notifier.py
+++ b/scripts/notifier.py
@@ -1,8 +1,18 @@
+from sendgrid import SendGridClient, Mail, SendGridError, SendGridClientError, SendGridServerError
+from jinja2 import Template
+
+# TODO - Set as os.environ var
+API_KEY = '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'
+
 def process_system_stats(system_stats):
     stats = {
+        'total': 0,
         'critical': None,
+        'total_critical': 0,
         'warn': None,
+        'total_warn': 0,
         'info': None,
+        'total_info': 0,
     }
 
     # A) Critical
@@ -21,14 +31,29 @@ def process_system_stats(system_stats):
 
     stats['critical'] = critical if critical else None
 
-    # TODO in future - warn & info
+    # TODO B & C - warn & info
+    warn = []
+    info = []
+
+    # D) Counts
+    stats['total_critical'] = len(critical)
+    stats['total_warn'] = len(warn)
+    stats['total_info'] = len(info)
+    stats['total'] = stats['total_critical'] + stats['total_warn'] + stats['total_info']
+
     return stats
 
 def process_project_stats(project_stats):
     stats = {
-        'critical': None,
-        'warn': None,
-        'info': None,
+        'collectors': {
+            'total': 0,
+            'critical': None,
+            'total_critical': 0,
+            'warn': None,
+            'total_warn': 0,
+            'info': None,
+            'total_info': 0,
+        }
     }
 
     # A) Critical
@@ -46,39 +71,101 @@ def process_project_stats(project_stats):
                 'message': 'Collector "%s" is running without a connection to the Streaming API' % collector['collector_name'],
             })
 
-    stats['critical'] = critical if critical else None
+    stats['collectors']['critical'] = critical if critical else None
+    stats['collectors']['total_critical'] = len(critical)
+    stats['collectors']['total'] = len(critical)
 
     # TODO in future - warn & info
     # TODO in future - stats for processor & inserter
+
     return stats
 
+def generate_email_text(report):
+    template = Template("""
+        <html>
+        <body>
+        <h1>STACKS System Status Update</h1>
+
+        <hr />
+
+        {% if report['system']['total'] %}
+            <h2>System Issues - {{ report['system']['total'] }}</h2>
+
+            {% if report['system']['critical'] %}
+            <h3>CRITICAL System Issues - {{ report['system']['total_critical'] }}</h3>
+            {% for issue in report['system']['critical'] %}
+                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+            {% endfor %}
+            {% endif %}
+
+            {% if report['system']['warn'] %}
+            <h3>WARN System Issues - {{ report['system']['total_warn'] }}</h3>
+            {% for issue in report['system']['warn'] %}
+                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+            {% endfor %}
+            {% endif %}
+
+            {% if report['system']['info'] %}
+            <h3>INFO System Issues - {{ report['system']['total_info'] }}</h3>
+            {% for issue in report['system']['info'] %}
+                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+            {% endfor %}
+            {% endif %}
+        {% endif %}
+
+        {% if report['project']['collectors']['total'] %}
+            <h2>Collector Issues - {{ report['project']['collectors']['total'] }}</h2>
+
+            {% if report['project']['collectors']['critical'] %}
+            <h3>CRITICAL System Issues - {{ report['project']['collectors']['total_critical'] }}</h3>
+            {% for issue in report['project']['collectors']['critical'] %}
+                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+            {% endfor %}
+            {% endif %}
+
+            {% if report['project']['collectors']['warn'] %}
+            <h3>WARN System Issues - {{ report['project']['collectors']['total_warn'] }}</h3>
+            {% for issue in report['project']['collectors']['warn'] %}
+                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+            {% endfor %}
+            {% endif %}
+
+            {% if report['project']['collectors']['info'] %}
+            <h3>INFO System Issues - {{ report['project']['collectors']['total_info'] }}</h3>
+            {% for issue in report['project']['collectors']['info'] %}
+                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+            {% endfor %}
+            {% endif %}
+        {% endif %}
+
+        </body>
+        </html>
+    """)
+
+    return template.render(report=report)
+
 def send_email(report):
-    print report
+    sg = SendGridClient(API_KEY, raise_errors=True)
+
+    message = Mail()
+    message.add_to('Billy Ceskavich <bceskavich@gmail.com>')
+    message.set_subject('STACKS Status Update')
+    message.set_html(generate_email_text(report))
+    message.set_from('STACKS <noreply@bits.ischool.syr.edu>')
+
+    try:
+        sg.send(message)
+    except SendGridError as e:
+        print e
+    except SendGridClientError as e:
+        print e
+    except SendGridServerError as e:
+        print e
 
 def process_and_notify(system_stats, project_stats):
-    report = {
-        'CRITICAL': {
-            'system': None,
-            'project': None,
-        },
-        'WARN': {
-            'system': None,
-            'project': None,
-        },
-        'INFO': {
-            'system': None,
-            'project': None,
-        },
-    }
-
-    system = process_system_stats(system_stats)
-    report['CRITICAL']['system'] = system['critical']
-    report['WARN']['system'] = system['warn']
-    report['INFO']['system'] = system['info']
-
-    project = process_project_stats(project_stats)
-    report['CRITICAL']['project'] = project['critical']
-    report['WARN']['project'] = project['warn']
-    report['INFO']['project'] = project['info']
+    # Empty report dict to be populated with stats
+    report = {}
+    report['system'] = process_system_stats(system_stats)
+    report['project'] = process_project_stats(project_stats)
 
     send_email(report) #, project_stats['email'])

--- a/scripts/notifier.py
+++ b/scripts/notifier.py
@@ -1,0 +1,84 @@
+def process_system_stats(system_stats):
+    stats = {
+        'critical': None,
+        'warn': None,
+        'info': None,
+    }
+
+    # A) Critical
+    critical = []
+    if system_stats['avail_space'] < 20:
+        critical.append({
+            'title': 'Storage Space Low - %d' % system_stats['avail_space'],
+            'message': 'System storage space is below 20GB, now at %dGB' % system_stats['avail_space'],
+        })
+
+    if not system_stats['mongo_running']:
+        critical.append({
+            'title': 'Mongo Error',
+            'message': 'MongoDB has stopped running on the server!',
+        })
+
+    stats['critical'] = critical if critical else None
+
+    # TODO in future - warn & info
+    return stats
+
+def process_project_stats(project_stats):
+    stats = {
+        'critical': None,
+        'warn': None,
+        'info': None,
+    }
+
+    # A) Critical
+    critical = []
+    for collector in project_stats['collectors']:
+        if collector['flags']['run'] and not collector['daemon_running']:
+            critical.append({
+                'title': 'Unexpected process termination',
+                'message': 'Collector "%s" has stopped without being flagged to do so.' % collector['collector_name'],
+            })
+
+        if collector['flags']['collect'] and collector['network'] == 'twitter' and not collector['listener_running']:
+            critical.append({
+                'title': 'Collector running without listener',
+                'message': 'Collector "%s" is running without a connection to the Streaming API' % collector['collector_name'],
+            })
+
+    stats['critical'] = critical if critical else None
+
+    # TODO in future - warn & info
+    # TODO in future - stats for processor & inserter
+    return stats
+
+def send_email(report):
+    print report
+
+def process_and_notify(system_stats, project_stats):
+    report = {
+        'CRITICAL': {
+            'system': None,
+            'project': None,
+        },
+        'WARN': {
+            'system': None,
+            'project': None,
+        },
+        'INFO': {
+            'system': None,
+            'project': None,
+        },
+    }
+
+    system = process_system_stats(system_stats)
+    report['CRITICAL']['system'] = system['critical']
+    report['WARN']['system'] = system['warn']
+    report['INFO']['system'] = system['info']
+
+    project = process_project_stats(project_stats)
+    report['CRITICAL']['project'] = project['critical']
+    report['WARN']['project'] = project['warn']
+    report['INFO']['project'] = project['info']
+
+    send_email(report) #, project_stats['email'])

--- a/scripts/notifier.py
+++ b/scripts/notifier.py
@@ -1,5 +1,7 @@
+import os
+
 from sendgrid import SendGridClient, Mail, SendGridError, SendGridClientError, SendGridServerError
-from jinja2 import Template
+from jinja2 import Environment, FileSystemLoader
 
 # TODO - Set as os.environ var
 API_KEY = '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'
@@ -81,74 +83,16 @@ def process_project_stats(project_stats):
     return stats
 
 def generate_email_text(report):
-    template = Template("""
-        <html>
-        <body>
-        <h1>STACKS System Status Update</h1>
+    loader = FileSystemLoader(os.path.abspath(os.path.dirname(__file__)) + '/templates')
+    env = Environment(loader=loader)
 
-        <hr />
-
-        {% if report['system']['total'] %}
-            <h2>System Issues - {{ report['system']['total'] }}</h2>
-
-            {% if report['system']['critical'] %}
-            <h3>CRITICAL System Issues - {{ report['system']['total_critical'] }}</h3>
-            {% for issue in report['system']['critical'] %}
-                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
-            {% endfor %}
-            {% endif %}
-
-            {% if report['system']['warn'] %}
-            <h3>WARN System Issues - {{ report['system']['total_warn'] }}</h3>
-            {% for issue in report['system']['warn'] %}
-                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
-            {% endfor %}
-            {% endif %}
-
-            {% if report['system']['info'] %}
-            <h3>INFO System Issues - {{ report['system']['total_info'] }}</h3>
-            {% for issue in report['system']['info'] %}
-                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
-            {% endfor %}
-            {% endif %}
-        {% endif %}
-
-        {% if report['project']['collectors']['total'] %}
-            <h2>Collector Issues - {{ report['project']['collectors']['total'] }}</h2>
-
-            {% if report['project']['collectors']['critical'] %}
-            <h3>CRITICAL System Issues - {{ report['project']['collectors']['total_critical'] }}</h3>
-            {% for issue in report['project']['collectors']['critical'] %}
-                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
-            {% endfor %}
-            {% endif %}
-
-            {% if report['project']['collectors']['warn'] %}
-            <h3>WARN System Issues - {{ report['project']['collectors']['total_warn'] }}</h3>
-            {% for issue in report['project']['collectors']['warn'] %}
-                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
-            {% endfor %}
-            {% endif %}
-
-            {% if report['project']['collectors']['info'] %}
-            <h3>INFO System Issues - {{ report['project']['collectors']['total_info'] }}</h3>
-            {% for issue in report['project']['collectors']['info'] %}
-                <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
-            {% endfor %}
-            {% endif %}
-        {% endif %}
-
-        </body>
-        </html>
-    """)
-
-    return template.render(report=report)
+    return env.get_template('status_email.html').render(report=report)
 
 def send_email(report):
     sg = SendGridClient(API_KEY, raise_errors=True)
 
     message = Mail()
-    message.add_to('Billy Ceskavich <bceskavich@gmail.com>')
+    message.add_to(report['project_details']['email'])
     message.set_subject('STACKS Status Update')
     message.set_html(generate_email_text(report))
     message.set_from('STACKS <noreply@bits.ischool.syr.edu>')
@@ -167,5 +111,9 @@ def process_and_notify(system_stats, project_stats):
     report = {}
     report['system'] = process_system_stats(system_stats)
     report['project'] = process_project_stats(project_stats)
+    report['project_details'] = {
+        'project_name': project_stats['project_name'],
+        'email': project_stats['email']
+    }
 
     send_email(report) #, project_stats['email'])

--- a/scripts/status_checker.py
+++ b/scripts/status_checker.py
@@ -12,15 +12,14 @@ def get_mongo_docs():
 
     projects = []
     for project in config_db.find():
-        # TODO - Change to admin
-        if 'project_name' in project.keys() and ('admin' not in project.keys() or not project['admin']):
+        if 'email' in project.keys() and ('admin' not in project.keys() or not project['admin']):
             project['_id'] = str(project['_id'])
 
             projects.append({
                 'id': str(project['_id']),
                 'project_name': project['project_name'],
                 'configdb': project['configdb'],
-                # 'email': project['email'],
+                'email': project['email'],
                 'collectors': project['collectors']
             })
 
@@ -39,8 +38,6 @@ def get_mongo_docs():
                 project['collectors'].append({
                     'id': str(cdoc['_id']),
                     'collector_name': cdoc['collector_name'],
-                    # 'start_time': cdoc['start_time'],
-                    # 'end_time': cdoc['end_time'],
                     'active': cdoc['active'],
                     'flags': cdoc['collector'],
                     'network': cdoc['network']

--- a/scripts/status_checker.py
+++ b/scripts/status_checker.py
@@ -1,0 +1,88 @@
+import json
+import subprocess
+
+from pymongo import MongoClient
+from bson.objectid import ObjectId
+from check_collectors import get_collector_status
+from notifier import process_and_notify
+
+def get_mongo_docs():
+    connection = MongoClient()
+    config_db = connection.config.config
+
+    projects = []
+    for project in config_db.find():
+        # TODO - Change to admin
+        if 'project_name' in project.keys() and ('admin' not in project.keys() or not project['admin']):
+            project['_id'] = str(project['_id'])
+
+            projects.append({
+                'id': str(project['_id']),
+                'project_name': project['project_name'],
+                'configdb': project['configdb'],
+                # 'email': project['email'],
+                'collectors': project['collectors']
+            })
+
+    for project in projects:
+        project_db = connection[project['configdb']].config
+
+        collectors = project['collectors']
+        project['collectors'] = []
+
+        for collector in collectors:
+            cid = collector['collector_id']
+            cdoc = project_db.find_one(ObjectId(cid))
+
+            # Only want twitter collectors that track the listener thread
+            if (cdoc['network'] == 'twitter' and 'listener_running' in cdoc.keys()) or cdoc['network'] != 'twitter':
+                project['collectors'].append({
+                    'id': str(cdoc['_id']),
+                    'collector_name': cdoc['collector_name'],
+                    # 'start_time': cdoc['start_time'],
+                    # 'end_time': cdoc['end_time'],
+                    'active': cdoc['active'],
+                    'flags': cdoc['collector'],
+                    'network': cdoc['network']
+                })
+
+    return projects
+
+def check_diskspace():
+    df = subprocess.Popen(['df', '-h'], stdout=subprocess.PIPE)
+    avail = int(df.communicate()[0].split('\n')[1].split()[3].split('G')[0])
+
+    return avail
+
+def check_mongo_status():
+    pgrep = subprocess.Popen(['pgrep', 'mongo'], stdout=subprocess.PIPE)
+    status = pgrep.communicate()[0]
+
+    if status:
+        return True
+    else:
+        return False
+
+def main():
+    # Dict to be used for storing status info
+    status_dict = {}
+
+    # Part 1 - System status
+    status_dict['system'] = {
+        'avail_space': check_diskspace(),
+        'mongo_running': check_mongo_status(),
+    }
+
+    # Part 2 - Status for each project & its given processes
+    projects = get_mongo_docs()
+    if projects:
+        for project in projects:
+            for collector in project['collectors']:
+               collector = get_collector_status(project, collector)
+
+        status_dict['projects'] = projects
+        for project in status_dict['projects']:
+            process_and_notify(status_dict['system'], project)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/status_checker.py
+++ b/scripts/status_checker.py
@@ -13,8 +13,6 @@ def get_mongo_docs():
     projects = []
     for project in config_db.find():
         if 'email' in project.keys() and ('admin' not in project.keys() or not project['admin']):
-            project['_id'] = str(project['_id'])
-
             projects.append({
                 'id': str(project['_id']),
                 'project_name': project['project_name'],

--- a/scripts/status_checker.py
+++ b/scripts/status_checker.py
@@ -1,4 +1,4 @@
-import json
+import sys
 import subprocess
 
 from pymongo import MongoClient
@@ -58,7 +58,7 @@ def check_mongo_status():
     else:
         return False
 
-def main():
+def main(report_type):
     # Dict to be used for storing status info
     status_dict = {}
 
@@ -77,7 +77,17 @@ def main():
 
         status_dict['projects'] = projects
         for project in status_dict['projects']:
-            process_and_notify(status_dict['system'], project)
+            process_and_notify(status_dict['system'], project, report_type)
 
 if __name__ == '__main__':
-    main()
+    reports = [
+        'system_check',
+        'report'
+    ]
+    report_type = sys.argv[1]
+
+    if report_type not in reports:
+        print 'Report type {} not valid'.format(report_type)
+        sys.exit(1)
+    else:
+        main(report_type)

--- a/scripts/templates/status_email.html
+++ b/scripts/templates/status_email.html
@@ -1,0 +1,59 @@
+<html>
+    <body>
+    <h1>STACKS System Status Update</h1>
+    <p><em>Project</em> - {{ report['project_details']['project_name'] }}</p>
+
+    <hr />
+
+    {% if report['system']['total'] %}
+        <h2>System Issues - {{ report['system']['total'] }}</h2>
+
+        {% if report['system']['critical'] %}
+        <h3>CRITICAL System Issues - {{ report['system']['total_critical'] }}</h3>
+        {% for issue in report['system']['critical'] %}
+            <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+        {% endfor %}
+        {% endif %}
+
+        {% if report['system']['warn'] %}
+        <h3>WARN System Issues - {{ report['system']['total_warn'] }}</h3>
+        {% for issue in report['system']['warn'] %}
+            <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+        {% endfor %}
+        {% endif %}
+
+        {% if report['system']['info'] %}
+        <h3>INFO System Issues - {{ report['system']['total_info'] }}</h3>
+        {% for issue in report['system']['info'] %}
+            <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+        {% endfor %}
+        {% endif %}
+    {% endif %}
+
+    {% if report['project']['collectors']['total'] %}
+        <h2>Collector Issues - {{ report['project']['collectors']['total'] }}</h2>
+
+        {% if report['project']['collectors']['critical'] %}
+        <h3>CRITICAL System Issues - {{ report['project']['collectors']['total_critical'] }}</h3>
+        {% for issue in report['project']['collectors']['critical'] %}
+            <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+        {% endfor %}
+        {% endif %}
+
+        {% if report['project']['collectors']['warn'] %}
+        <h3>WARN System Issues - {{ report['project']['collectors']['total_warn'] }}</h3>
+        {% for issue in report['project']['collectors']['warn'] %}
+            <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+        {% endfor %}
+        {% endif %}
+
+        {% if report['project']['collectors']['info'] %}
+        <h3>INFO System Issues - {{ report['project']['collectors']['total_info'] }}</h3>
+        {% for issue in report['project']['collectors']['info'] %}
+            <p><strong>{{ issue['title'] }}</strong><br />{{ issue['message'] }}</p>
+        {% endfor %}
+        {% endif %}
+    {% endif %}
+
+    </body>
+</html>


### PR DESCRIPTION
This PR contains two feature updates to STACKS: reporting emails & stream rate limit logging
### Stream Rate Limit Logging
- STACKS now collects stream limit notices via raw JSON files and passes them down the insertion pipeline.
- We also collect limit counts in Mongo per collector (vs. project-wide limit counts stored in Mongo)
- Limit notices are stored in a project's main DB under the "limits" collection
- Limit notices are formatted as such, where the "track" key notes the number of tweets missed and "timestamp_ms" is a Unix style timestamp of the limit notice

``` JSON
 { "limit": { "track": "X", "time": "YYYY-MM-DDTHH:MM:SS", "timestamp_ms": "X"}}
```

**Questions**
1. Do we want to include count reports somewhere on the front-end of STACKS. If so, where?
2. Since the limits collection will contain notices for all collectors in an account, should we include an additional field that notes the collector name for the limit notice?
### Status Emails
- Located in the `scripts` directory, I have put together a series of Python scripts that, when run, will create status reports for current project accounts and collectors.
- At the moment, the reports will send notices for the following **critical** errors:
  - _Project Level_ - HDD space is less than 20GB; Mongo has stopped
  - _Collector Level_ - A collector has terminated unexpectedly; a collector is running but the connection to the Twitter API has terminated unexpectedly
- The scripts can be easily extended to include additional reports for other processes, and reports at the **warning** and **info** level
- `scripts/crontab.txt` contains the logic needed to run two cronjobs to manage these scripts
  - 1) Runs every 15 minutes and sends report emails upon a new issue arising
  - 2) Runs once a day and sends daily reports, if there is anything to report
- Running `bash install` after installation will call a shell script to set up these cronjobs. Alternatively one could run `crontab scripts/crontab.txt`
- Status emails are sent to an email owned by the project account. New signups via the front or back-end will ask for an email
- These scripts can run on a server with older projects that don't include emails, it will simply skip over them

**TODO**
1) I have yet to build a front-end interface to manage the reporting interval

/cc
@jhemsley 
