### PR TITLE
Change the feed limit to 100 as this is the new Facebook API limit.

### DIFF
--- a/app/facebook/facebook.py
+++ b/app/facebook/facebook.py
@@ -22,7 +22,7 @@ class Facebook(object):
         # Load in access token via app-level call
         self.access_token = self._get_access_token()
 
-    def get_object_feed(self, id, limit=250, since=None, until=None):
+    def get_object_feed(self, id, limit=100, since=None, until=None):
         """
         Public method to grab feed from an object
 


### PR DESCRIPTION
Facebook API now limits requests to 100 objects. Previous code had 250 objects as the default and the API was returning an error.
